### PR TITLE
Fixing linting error in test

### DIFF
--- a/test/statistics.test.js
+++ b/test/statistics.test.js
@@ -397,7 +397,7 @@ describe('descriptiveStatistics', () => {
   it('descriptiveStatistics([4, 2, 6, 1, 3, 7, 5, 3]) should return a number and not modify the argument', done => {
     let arg = [4, 2, 6, 1, 3, 7, 5, 3]
     let res = statistics.descriptiveStatistics(arg)
-    expect(res).to.be.an('object').that.includes({maximum: 7})
+    expect(res).to.be.an('object').that.includes({ maximum: 7 })
     expect(arg).to.eql([4, 2, 6, 1, 3, 7, 5, 3])
     done()
   })


### PR DESCRIPTION
Running `npm run lint` generated from the `test/statistics.test.js`.

```
 400:50  error  A space is required after '{'
 400:61  error  A space is required before '}'
```